### PR TITLE
Update base to fix compilation with GHC 7.8

### DIFF
--- a/greencard.cabal
+++ b/greencard.cabal
@@ -1,5 +1,5 @@
 Name: greencard
-Version: 3.0.4.1
+Version: 3.0.4.2
 Synopsis: GreenCard, a foreign function pre-processor for Haskell.
 Description:
    Green Card is a foreign function interface preprocessor for Haskell, simplifying the
@@ -59,12 +59,12 @@ library {
   Exposed-Modules: Foreign.GreenCard
   include-dirs: lib
   install-includes: GreenCard.gc
-  build-depends: base <= 5
+  build-depends: base >= 4.7 && <= 5
 }
 
 executable greencard {
   main-is:        GreenCard.lhs
-  build-depends:  base <= 5, pretty, containers, array
+  build-depends:  base >= 4.7 && <= 5, pretty, containers, array
   hs-source-dirs: src
   c-sources:      src/ErrorHook.c
   other-modules:  Process

--- a/greencard.cabal
+++ b/greencard.cabal
@@ -1,5 +1,5 @@
 Name: greencard
-Version: 3.0.4
+Version: 3.0.4.1
 Synopsis: GreenCard, a foreign function pre-processor for Haskell.
 Description:
    Green Card is a foreign function interface preprocessor for Haskell, simplifying the
@@ -23,6 +23,7 @@ License: BSD3
 License-file: LICENSE
 Author: Alastair Reid <alastair@reid-consulting-uk.ltd.uk>, Sigbjorn Finne <sof@forkIO.com>, Thomas Nordin.
 Maintainer: Sigbjorn Finne <sof@forkIO.com>
+Homepage: https://github.com/sof/greencard
 Cabal-version: >= 1.2
 Build-type: Simple
 Extra-source-files: README


### PR DESCRIPTION
This pull request should be enough to fix issue #1. I noticed that the version on Hackage included a minor change not included in the repo, so I first imported that. I then made another commit on top of it that bumps the version number and raises the base requirement to at least 4.7.

This way, GHC 7.8.x users will get the new version of the package, which will have been built with the version of `happy` appropriate for them. GHC 7.6.x and below users will get the previous version of the package, which will still work for them. Packages that depend on greencard can thus simply require "greencard >= 3.0.4 && < 3.1" and successfully build, whether on GHC 7.6.x or GHC 7.8.x.
